### PR TITLE
Fix: necessary quotes in .bat snippets

### DIFF
--- a/docs/Server-Hosting/ServerHosting.md
+++ b/docs/Server-Hosting/ServerHosting.md
@@ -85,12 +85,12 @@ Continue to: [How to Launch Server on Windows](#How-to-Launch-Server-on-Windows)
 
     === "Internet"
         ```batch
-        start %~dp0ServerHelper.bat +InternetServer/MyServer
+        start "" "%~dp0ServerHelper.bat" +InternetServer/MyServer
         ```
 
     === "LAN"
         ```batch
-        start %~dp0ServerHelper.bat +LanServer/MyServer
+        start "" "%~dp0ServerHelper.bat" +LanServer/MyServer
         ```
 
     !!! note


### PR DESCRIPTION
Hello! The current docs don't quite work for **How to Launch Server on Windows**, due to some missing quotation marks in the sample .bat code snippets.

This PR contains one commit, which simply puts two sets of quotes where they need to be in the Internet Server and LAN Server snippets.

Reasons for adding quotes:
- Surrounded `%dp0` in quotes to accommodate users whose paths include a dir with spaces in the name.
- The argument +InternetServer/MyServer was being interpreted as a file path due to missing (positional) `title` param after `start` command

**PLEASE NOTE:** The Windows (.bat) section was updated, but NOT Linux (bash) section. I don't have bash experience and can't tinker with it at the moment.

I hope y'all are well!