### PR TITLE
Patch 8

### DIFF
--- a/docs/Modding/AssetBundles.md
+++ b/docs/Modding/AssetBundles.md
@@ -31,7 +31,10 @@ When beginning development of 3.0, it was key to support runtime loading of cust
 
 ## Content Bundles (*.content)
 
-This format is used by devkit landscapes, material palettes and radio songs, but is unlikely to see any further use in favor of master bundles. Ideally support for these usages will be transitioned to master bundles.
+!!! warning
+    The game will no longer load .content files due to the fact that master bundles can now support all the features of a .content file. Alongside that, the tool for it has been removed from the Project.unitypackage
+
+This format was by devkit landscapes, material palettes and radio songs, but has now replaced by master bundles.
 
 ### Tool Usage
 

--- a/docs/Modding/AssetBundles.md
+++ b/docs/Modding/AssetBundles.md
@@ -32,7 +32,7 @@ When beginning development of 3.0, it was key to support runtime loading of cust
 ## Content Bundles (*.content)
 
 !!! warning
-    The game will no longer load .content files due to the fact that master bundles can now support all the features of a .content file. Alongside that, the tool for it has been removed from the Project.unitypackage
+    The game no longer loads .content files. MasterBundles now support all the features of a .content file, and the .content file tooling has been removed from Project.unitypackage
 
 This format was by devkit landscapes, material palettes and radio songs, but has now replaced by master bundles.
 

--- a/docs/Modding/AssetPropertiesReferences/ItemData.md
+++ b/docs/Modding/AssetPropertiesReferences/ItemData.md
@@ -239,6 +239,10 @@ __Action\_#\_Blueprint\_#\_Index__: ID of the specific blueprint this action sho
 
 __Action\_#\_Key__: `Craft_Bandage`, `Craft_Dressing`, `Craft_Rag`, `Craft_Seed`
 
+__Action\_#\_Text__: Text shown on the action button.
+
+__Action\_#\_Tooltip__: Tooltip shown when hovering over the action button.
+
 ## Asset Bundles and Error Handling
 
 See [AssetBundles.md](../AssetBundles.md) for full documentation regarding asset bundles.

--- a/docs/Modding/AssetPropertiesReferences/ItemData.md
+++ b/docs/Modding/AssetPropertiesReferences/ItemData.md
@@ -239,10 +239,6 @@ __Action\_#\_Blueprint\_#\_Index__: ID of the specific blueprint this action sho
 
 __Action\_#\_Key__: `Craft_Bandage`, `Craft_Dressing`, `Craft_Rag`, `Craft_Seed`
 
-__Action\_#\_Text__: Text shown on the action button.
-
-__Action\_#\_Tooltip__: Tooltip shown when hovering over the action button.
-
 ## Asset Bundles and Error Handling
 
 See [AssetBundles.md](../AssetBundles.md) for full documentation regarding asset bundles.

--- a/docs/Modding/AssetTesting.md
+++ b/docs/Modding/AssetTesting.md
@@ -1,0 +1,13 @@
+# Testing Assets
+
+When creating custom content for Unturned, you'll need to test your assets for bugs and kinks. Here are some methods of easily reloading your assets.
+
+## Reload Command
+
+In 3.19.18.0 the __reload__ command was introduced which can be used to reload specific assets or directories of assets while playing. For example:
+
+    /reload 6b91a94f01b6472eaca31d9420ec2367
+
+## Reload All Assets
+
+In order to reload all core, workshop, and custom assets, just press the reload assets hotkey, which is defaulted to `pg up`. After pressing this button your game will reload all of your assets without the need of restarting the game.

--- a/docs/Modding/AssetTesting.md
+++ b/docs/Modding/AssetTesting.md
@@ -1,6 +1,6 @@
 # Testing Assets
 
-When creating custom content for Unturned, you'll need to test your assets for bugs and kinks. Here are some methods of easily reloading your assets.
+When creating custom content for Unturned, you'll need to test your assets for bugs. Here are some methods of easily reloading your assets.
 
 ## Reload Command
 

--- a/docs/Modding/GUID.md
+++ b/docs/Modding/GUID.md
@@ -4,4 +4,4 @@ Globally Unique Identifiers (**GUID**s) are 32 digit numbers used to identify as
 
 At the time of writing a useful tool for generating GUIDs is: https://www.guidgenerator.com/
 
-Legacy ids are 16 bits with a [0, 65535] range, whereas GUIDs are 128 bits with an unimaginably huge range. This allows them to be generated without coordination or registration between developers.
+Legacy IDs are 16 bits with a [0, 65535] range, whereas GUIDs are 128 bits with an unimaginably huge range. This allows them to be generated without coordination or registration between developers. The main goal was to replace the legacy ushort IDs with GUIDs, but that goal fell out of reach. It is quite important to note that while the legacy IDs are used mainly, asset conflicts can still occur with GUIDs, similar to that of what happened to Roll4Charm's structures.

--- a/docs/Modding/GUID.md
+++ b/docs/Modding/GUID.md
@@ -4,4 +4,4 @@ Globally Unique Identifiers (**GUID**s) are 32 digit numbers used to identify as
 
 At the time of writing a useful tool for generating GUIDs is: https://www.guidgenerator.com/
 
-Legacy IDs are 16 bits with a [0, 65535] range, whereas GUIDs are 128 bits with an unimaginably huge range. This allows them to be generated without coordination or registration between developers. The main goal was to replace the legacy ushort IDs with GUIDs, but that goal fell out of reach. It is quite important to note that while the legacy IDs are used mainly, asset conflicts can still occur with GUIDs, similar to that of what happened to Roll4Charm's structures.
+Legacy IDs are unsigned 16 bit integers with a [0, 65535] range, whereas GUIDs are 128 bits with an unimaginably huge range. This allows them to be generated without coordination or registration between developers. The main goal was to replace the legacy ushort IDs with GUIDs, but that goal fell out of reach. It is quite important to note that while the legacy IDs are used mainly, asset conflicts can still occur with GUIDs, similar to that of what happened to Roll4Charm's structures.

--- a/docs/Modding/GUID.md
+++ b/docs/Modding/GUID.md
@@ -4,4 +4,4 @@ Globally Unique Identifiers (**GUID**s) are 32 digit numbers used to identify as
 
 At the time of writing a useful tool for generating GUIDs is: https://www.guidgenerator.com/
 
-Legacy IDs are unsigned 16 bit integers with a [0, 65535] range, whereas GUIDs are 128 bits with an unimaginably huge range. This allows them to be generated without coordination or registration between developers. The main goal was to replace the legacy ushort IDs with GUIDs, but that goal fell out of reach. It is quite important to note that while the legacy IDs are used mainly, asset conflicts can still occur with GUIDs, similar to that of what happened to Roll4Charm's structures.
+Legacy IDs are unsigned 16 bit integers with a [0, 65535] range, whereas GUIDs are 128 bits with an unimaginably huge range. This allows them to be generated without coordination or registration between developers. The main goal was to replace the legacy ushort IDs with GUIDs, but that goal fell out of reach. It is quite important to note that while the legacy IDs are used mainly, asset conflicts can still occur with GUIDs.

--- a/docs/Modding/GettingStarted.md
+++ b/docs/Modding/GettingStarted.md
@@ -26,4 +26,4 @@ This package contains vanilla content examples, and several useful prefabs:
 - Assets/Resources/Characters/Preview.prefab is helpful for previewing clothes.
 
 !!! warning
-    Custom content should NOT be placed into the CoreMasterBundle, instead create a separate directory.
+    Custom content should NOT be placed into the CoreMasterBundle, instead create a separate directory or place your custom content in the Sandbox folder located in your local game files.

--- a/docs/Modding/Unity2018.md
+++ b/docs/Modding/Unity2018.md
@@ -1,7 +1,7 @@
 # Upgrading from Unity 2017.4 LTS to 2018.4 LTS
 
 !!! attention
-    Unturned is now running on Unity 2019.4
+    Unturned is now running on Unity 2020.3 LTS.
 
 ## Asset Bundles
 

--- a/docs/Modding/mapmaking/Landscape.md
+++ b/docs/Modding/mapmaking/Landscape.md
@@ -12,9 +12,13 @@ Pros:
 Cons:
 
 - Devkit is not user-friendly, and improvements to it have been voted low priority.
-- Not all legacy editor features were ported (yet?), so the landscape has to be edited separately from roads, lighting, etc.
+- Not all legacy editor features were ported (yet?).
 
 ## Upgrade Legacy Terrain to Landscape
+
+
+!!! info
+    As of version [3.22.9.0](https://store.steampowered.com/news/app/304930/view/3212766758952510190 "3.22.9.0"), all legacy terrain will be converted automatically to the devkit landscape terrain. Along with that, in this version and future versions of the game, the devkit landscape terrain can now be edited within the regular legacy map editor.
 
 1. Level should have only one Landscape instance spawned from the Type Browser.
 2. Open the Ground Upgrade Wizard.

--- a/docs/Modding/mapmaking/Landscape.md
+++ b/docs/Modding/mapmaking/Landscape.md
@@ -18,7 +18,7 @@ Cons:
 
 
 !!! info
-    As of version [3.22.9.0](https://store.steampowered.com/news/app/304930/view/3212766758952510190 "3.22.9.0"), all legacy terrain will be converted automatically to the devkit landscape terrain. Along with that, in this version and future versions of the game, the devkit landscape terrain can now be edited within the regular legacy map editor.
+    Beginning in version [3.22.9.0](https://store.steampowered.com/news/app/304930/view/3212766758952510190 "3.22.9.0"), all legacy terrain will be converted automatically to the devkit landscape terrain. Additionally, devkit landscape terrain can now be edited within the regular legacy map editor.
 
 1. Level should have only one Landscape instance spawned from the Type Browser.
 2. Open the Ground Upgrade Wizard.

--- a/docs/Modding/mapmaking/Landscape.md
+++ b/docs/Modding/mapmaking/Landscape.md
@@ -12,7 +12,7 @@ Pros:
 Cons:
 
 - Devkit is not user-friendly, and improvements to it have been voted low priority.
-- Not all legacy editor features were ported (yet?).
+- Not all legacy editor features have been ported.
 
 ## Upgrade Legacy Terrain to Landscape
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,7 +111,8 @@ nav:
     - Assets:
       - 'Modding/AssetTypes/AssetsV1.md'
       - 'Modding/AssetTypes/AssetsV2.md'
-      - 'Modding/AssetPtr.md'
+      - 'Modding/AssetPtr.md
+      - 'Modding/AssetTesting.md'
       - 'Modding/MasterBundlePtr.md'
     - 'Modding/AirdropAsset.md'
     - 'Modding/Animation.md'


### PR DESCRIPTION
## Jdance\'s Pull Request Patch 8

- Mentioned the Sandbox folder on the Getting Started with Modding page, this way people know to use it, check the commit for it to see a link to the issue that brought back this feature.

- Noted on the Asset Bundles page that .content files are no longer loaded by the game.

- Noted on Landscape.md that as of version 3.22.9.0, all legacy terrain will be converted automatically to the devkit landscape terrain.

- Fixed note in Unity2018.md to say that Unturned is now running on 2020.3 LTS.

- Added AssetTesting.md that provides information on easily reloading core, workshop, and custom assets.