### PR TITLE
mkdocs 8.X upgrade

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,7 +64,8 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.details
   - attr_list
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true 
   - pymdownx.tilde
   - pymdownx.magiclink:
       repo_url_shortener: true

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -2,14 +2,12 @@
 
 
 {% block announce %}
-  <style>
-      .md-announce a,
-      .md-announce a:focus,
-      .md-announce a:hover{color:currentColor}.md-announce
-      strong{white-space:nowrap}.md-announce}
-  </style>
-
-<a href="https://discord.gg/PgJCPh6">
+<style>
+  .announcement:not(:hover) {
+    color: #6c91d5;
+  }
+</style>
+<a href="https://discord.gg/PgJCPh6" class="announcement">
     For updates & questions join our
     <span class="twemoji">
             {% include ".icons/fontawesome/brands/discord.svg" %}

--- a/pdm.lock
+++ b/pdm.lock
@@ -72,11 +72,11 @@ dependencies = [
 
 [[package]]
 name = "jinja2"
-version = "2.11.3"
-requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "3.1.2"
+requires_python = ">=3.7"
 summary = "A very fast and expressive template engine."
 dependencies = [
-    "MarkupSafe>=0.23",
+    "MarkupSafe>=2.0",
 ]
 
 [[package]]
@@ -136,15 +136,16 @@ dependencies = [
 
 [[package]]
 name = "mkdocs-material"
-version = "7.3.6"
-summary = "A Material Design theme for MkDocs"
+version = "8.4.1"
+requires_python = ">=3.7"
+summary = "Documentation that simply works"
 dependencies = [
-    "jinja2>=2.11.1",
+    "jinja2>=3.0.2",
     "markdown>=3.2",
-    "mkdocs-material-extensions>=1.0",
-    "mkdocs>=1.2.3",
-    "pygments>=2.10",
-    "pymdown-extensions>=9.0",
+    "mkdocs-material-extensions>=1.0.3",
+    "mkdocs>=1.3.0",
+    "pygments>=2.12",
+    "pymdown-extensions>=9.4",
 ]
 
 [[package]]
@@ -167,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "mkdocs-redirects"
-version = "1.0.4"
+version = "1.1.0"
 requires_python = ">=2.7"
 summary = "A MkDocs plugin for dynamic page redirects to prevent broken links."
 dependencies = [
@@ -265,7 +266,7 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 
 [metadata]
 lock_version = "4.0"
-content_hash = "sha256:be7b609ac5c4b3ed137e353b47e6c09dd54004c8d81ca74f1e18e7efb924310d"
+content_hash = "sha256:13a20d9a66702b0d360d6d6161300a1ae78be34222c931d362c29985dc3f0d81"
 
 [metadata.files]
 "babel 2.10.3" = [
@@ -302,9 +303,9 @@ content_hash = "sha256:be7b609ac5c4b3ed137e353b47e6c09dd54004c8d81ca74f1e18e7efb
     {url = "https://files.pythonhosted.org/packages/1a/16/441080c907df829016729e71d8bdd42d99b9bdde48b01492ed08912c0aa9/importlib_metadata-4.12.0.tar.gz", hash = "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670"},
     {url = "https://files.pythonhosted.org/packages/d2/a2/8c239dc898138f208dd14b441b196e7b3032b94d3137d9d8453e186967fc/importlib_metadata-4.12.0-py3-none-any.whl", hash = "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"},
 ]
-"jinja2 2.11.3" = [
-    {url = "https://files.pythonhosted.org/packages/4f/e7/65300e6b32e69768ded990494809106f87da1d436418d5f1367ed3966fd7/Jinja2-2.11.3.tar.gz", hash = "sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"},
-    {url = "https://files.pythonhosted.org/packages/7e/c2/1eece8c95ddbc9b1aeb64f5783a9e07a286de42191b7204d67b7496ddf35/Jinja2-2.11.3-py2.py3-none-any.whl", hash = "sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419"},
+"jinja2 3.1.2" = [
+    {url = "https://files.pythonhosted.org/packages/7a/ff/75c28576a1d900e87eb6335b063fab47a8ef3c8b4d88524c4bf78f670cce/Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
+    {url = "https://files.pythonhosted.org/packages/bc/c3/f068337a370801f372f2f8f6bad74a5c140f6fda3d9de154052708dd3c65/Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
 ]
 "jsmin 3.0.1" = [
     {url = "https://files.pythonhosted.org/packages/5e/73/e01e4c5e11ad0494f4407a3f623ad4d87714909f50b17a06ed121034ff6e/jsmin-3.0.1.tar.gz", hash = "sha256:c0959a121ef94542e807a674142606f7e90214a2b3d1eb17300244bbb5cc2bfc"},
@@ -396,9 +397,9 @@ content_hash = "sha256:be7b609ac5c4b3ed137e353b47e6c09dd54004c8d81ca74f1e18e7efb
     {url = "https://files.pythonhosted.org/packages/30/44/3d732ad3cb6e7875e216e0ef496939643ca46fb007806ac44e10b1b9cddb/mkdocs-git-revision-date-localized-plugin-1.1.0.tar.gz", hash = "sha256:38517e2084229da1a1b9460e846c2748d238c2d79efd405d1b9174a87bd81d79"},
     {url = "https://files.pythonhosted.org/packages/96/63/ea5d529d8a25fe68f56c199cbdc5408ff6ab5cd8b8f31f2f13f63c02e2ef/mkdocs_git_revision_date_localized_plugin-1.1.0-py3-none-any.whl", hash = "sha256:4ba0e49abea3e9f6ee26e2623ff7283873da657471c61f1d0cfbb986f403316d"},
 ]
-"mkdocs-material 7.3.6" = [
-    {url = "https://files.pythonhosted.org/packages/4d/e3/3148067f799a70ef277a41d2dc76d8ddfc92b51dc6b12ccafadfe4e5f487/mkdocs_material-7.3.6-py2.py3-none-any.whl", hash = "sha256:1b6b3e9e09f922c2d7f1160fe15c8f43d4adc0d6fb81aa6ff0cbc7ef5b78ec75"},
-    {url = "https://files.pythonhosted.org/packages/d4/a7/a7dc40d7249f4bdcd408833bb36ae2141365e9919c01858a5b1dff6ab666/mkdocs-material-7.3.6.tar.gz", hash = "sha256:1b1dbd8ef2508b358d93af55a5c5db3f141c95667fad802301ec621c40c7c217"},
+"mkdocs-material 8.4.1" = [
+    {url = "https://files.pythonhosted.org/packages/17/31/1887ba94815e6d3ec1f918cb0a1412e99e43317ee264c92fc2aea1c1e267/mkdocs-material-8.4.1.tar.gz", hash = "sha256:92c70f94b2e1f8a05d9e05eec1c7af9dffc516802d69222329db89503c97b4f3"},
+    {url = "https://files.pythonhosted.org/packages/26/ec/8eaf969cca0cf8fa75130c5fa995760148a4c9d105ab75fb8f1d1e211a84/mkdocs_material-8.4.1-py2.py3-none-any.whl", hash = "sha256:319a6254819ce9d864ff79de48c43842fccfdebb43e4e6820eef75216f8cfb0a"},
 ]
 "mkdocs-material-extensions 1.0.3" = [
     {url = "https://files.pythonhosted.org/packages/c1/6f/20b60ac8b314fd080dbab77b7a70ac3a283641a23914cb2346178875f501/mkdocs-material-extensions-1.0.3.tar.gz", hash = "sha256:bfd24dfdef7b41c312ede42648f9eb83476ea168ec163b613f9abd12bbfddba2"},
@@ -408,8 +409,8 @@ content_hash = "sha256:be7b609ac5c4b3ed137e353b47e6c09dd54004c8d81ca74f1e18e7efb
     {url = "https://files.pythonhosted.org/packages/d4/e0/f04340fc3765b085b15dacf061c06527e207826d5dde119bc3dce1b78686/mkdocs_minify_plugin-0.5.0-py2-none-any.whl", hash = "sha256:487c31ae6b8b3230f56910ce6bcf5c7e6ad9a8c4f51c720a4b989f30c2b0233f"},
     {url = "https://files.pythonhosted.org/packages/d6/18/b437c44727f4529d26f6425e7a234bde42839d36ca29521f7322882cc79b/mkdocs-minify-plugin-0.5.0.tar.gz", hash = "sha256:32d9e8fbd89327a0f4f648f517297aad344c1bad64cfde110d059bd2f2780a6d"},
 ]
-"mkdocs-redirects 1.0.4" = [
-    {url = "https://files.pythonhosted.org/packages/f8/f6/bbfe253c9674120c3e3bd0f36919cc80068f5189f2447ccb3f154cc24893/mkdocs-redirects-1.0.4.tar.gz", hash = "sha256:27aae239feab63ba3198af95b3614275c0699707009e81bbe452f6c6cf34f5d9"},
+"mkdocs-redirects 1.1.0" = [
+    {url = "https://files.pythonhosted.org/packages/03/8f/36087a772f5d5d806db9dfce46431b728e30f8d1383d72bbd3eedc8885d6/mkdocs-redirects-1.1.0.tar.gz", hash = "sha256:208d8d829e33eba86a801ada841b60ea9b149b8b0d48ff049e57383ec5367a12"},
 ]
 "packaging 21.3" = [
     {url = "https://files.pythonhosted.org/packages/05/8e/8de486cbd03baba4deef4142bd643a3e7bbe954a784dc1bb17142572d127/packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},

--- a/pdm.lock
+++ b/pdm.lock
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "mkdocs-material"
-version = "8.4.1"
+version = "8.4.3"
 requires_python = ">=3.7"
 summary = "Documentation that simply works"
 dependencies = [
@@ -397,9 +397,9 @@ content_hash = "sha256:13a20d9a66702b0d360d6d6161300a1ae78be34222c931d362c29985d
     {url = "https://files.pythonhosted.org/packages/30/44/3d732ad3cb6e7875e216e0ef496939643ca46fb007806ac44e10b1b9cddb/mkdocs-git-revision-date-localized-plugin-1.1.0.tar.gz", hash = "sha256:38517e2084229da1a1b9460e846c2748d238c2d79efd405d1b9174a87bd81d79"},
     {url = "https://files.pythonhosted.org/packages/96/63/ea5d529d8a25fe68f56c199cbdc5408ff6ab5cd8b8f31f2f13f63c02e2ef/mkdocs_git_revision_date_localized_plugin-1.1.0-py3-none-any.whl", hash = "sha256:4ba0e49abea3e9f6ee26e2623ff7283873da657471c61f1d0cfbb986f403316d"},
 ]
-"mkdocs-material 8.4.1" = [
-    {url = "https://files.pythonhosted.org/packages/17/31/1887ba94815e6d3ec1f918cb0a1412e99e43317ee264c92fc2aea1c1e267/mkdocs-material-8.4.1.tar.gz", hash = "sha256:92c70f94b2e1f8a05d9e05eec1c7af9dffc516802d69222329db89503c97b4f3"},
-    {url = "https://files.pythonhosted.org/packages/26/ec/8eaf969cca0cf8fa75130c5fa995760148a4c9d105ab75fb8f1d1e211a84/mkdocs_material-8.4.1-py2.py3-none-any.whl", hash = "sha256:319a6254819ce9d864ff79de48c43842fccfdebb43e4e6820eef75216f8cfb0a"},
+"mkdocs-material 8.4.3" = [
+    {url = "https://files.pythonhosted.org/packages/1e/2d/eff7d0e52cc03466e2c16c066164725ca7ab0a98fa40361bc80ea43f36de/mkdocs-material-8.4.3.tar.gz", hash = "sha256:f39af3234ce0b60024b7712995af0de5b5227ab6504f0b9c8709c9a770bd94bf"},
+    {url = "https://files.pythonhosted.org/packages/8e/16/eb27874bb851a56cadc2a122ac2964af866f64f9964346d500bed47aae63/mkdocs_material-8.4.3-py2.py3-none-any.whl", hash = "sha256:d5cc6f5023061a663514f61810052ad266f5199feafcf15ad23ea4891b21e6bc"},
 ]
 "mkdocs-material-extensions 1.0.3" = [
     {url = "https://files.pythonhosted.org/packages/c1/6f/20b60ac8b314fd080dbab77b7a70ac3a283641a23914cb2346178875f501/mkdocs-material-extensions-1.0.3.tar.gz", hash = "sha256:bfd24dfdef7b41c312ede42648f9eb83476ea168ec163b613f9abd12bbfddba2"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,10 @@ authors = [
     { name = "Khakers", email = "22665282+khakers@users.noreply.github.com" },
 ]
 dependencies = [
-    "mkdocs-material==7.*,>=7.2.6",
-    "jinja2<3.0.0,>=2.11.1",
+    "mkdocs-material==8.*,>=8.4.1",
     "mkdocs-git-revision-date-localized-plugin",
     "mkdocs-minify-plugin",
-    "mkdocs-redirects",
-    "markupsafe<2.1",
+    "mkdocs-redirects"
 ]
 requires-python = ">=3.7"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,33 @@
-mkdocs-material >= 7.2.6, == 7.*
-Jinja2>=2.11.1, <3.0.0
-mkdocs-git-revision-date-localized-plugin
-mkdocs-minify-plugin
-mkdocs-redirects
-# versions 2.1 and above remove a method that is required, and Jinja2 doesn't appear to have locked their versions to stop this from breaking everything
-MarkupSafe < 2.1
+babel==2.10.3
+click==8.1.3
+colorama==0.4.5
+csscompressor==0.9.5
+ghp-import==2.1.0
+gitdb==4.0.9
+GitPython==3.1.27
+htmlmin==0.1.12
+importlib-metadata==4.12.0
+jinja2==3.1.2
+jsmin==3.0.1
+Markdown==3.3.7
+MarkupSafe==2.0.1
+mergedeep==1.3.4
+mkdocs==1.3.1
+mkdocs-git-revision-date-localized-plugin==1.1.0
+mkdocs-material==8.4.1
+mkdocs-material-extensions==1.0.3
+mkdocs-minify-plugin==0.5.0
+mkdocs-redirects==1.1.0
+packaging==21.3
+pygments==2.12.0
+pymdown-extensions==9.5
+pyparsing==3.0.9
+python-dateutil==2.8.2
+pytz==2022.1
+PyYAML==6.0
+pyyaml-env-tag==0.1
+six==1.16.0
+smmap==5.0.0
+watchdog==2.1.9
+zipp==3.8.1
+--index-url https://pypi.org/simple


### PR DESCRIPTION
Upgrades mkdocs-material to the 8.4 and fixes the obvious issues. Doesn't implement any new version 8.0+ features